### PR TITLE
Introduce workspace and puha-lib crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,3 +5,10 @@ version = 4
 [[package]]
 name = "puha"
 version = "0.1.0"
+dependencies = [
+ "puha-lib",
+]
+
+[[package]]
+name = "puha-lib"
+version = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
-[package]
-name = "puha"
-version = "0.1.0"
-edition = "2024"
-
-[dependencies]
+[workspace]
+members = [
+    "puha",
+    "puha-lib"
+]
+resolver = "2"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # puha
-This is a cli tool to help me keep track of the things I own.
+
+This workspace contains:
+
+- **puha-lib**: a library providing puha's core functionality.
+- **puha**: the command-line interface that wraps the library.

--- a/puha-lib/Cargo.toml
+++ b/puha-lib/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "puha-lib"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]

--- a/puha-lib/src/lib.rs
+++ b/puha-lib/src/lib.rs
@@ -1,0 +1,14 @@
+/// Returns a greeting string from `puha-lib`.
+pub fn greet() -> &'static str {
+    "Hello from puha-lib!"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn greet_returns_expected() {
+        assert_eq!(greet(), "Hello from puha-lib!");
+    }
+}

--- a/puha/Cargo.toml
+++ b/puha/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "puha"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+puha-lib = { path = "../puha-lib" }

--- a/puha/src/main.rs
+++ b/puha/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("{}", puha_lib::greet());
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("Hello, world!");
-}


### PR DESCRIPTION
## Summary
- convert project to a workspace
- add new library crate `puha-lib`
- use the library from the `puha` binary
- update README to explain the new structure

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684615c25a588331a5a44719356e985f