### PR TITLE
Add serde JSON serialization support

### DIFF
--- a/puha-lib/Cargo.toml
+++ b/puha-lib/Cargo.toml
@@ -4,3 +4,8 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[dev-dependencies]
+tempfile = "3"

--- a/puha-lib/src/lib.rs
+++ b/puha-lib/src/lib.rs
@@ -1,9 +1,11 @@
+use serde::{Deserialize, Serialize};
+
 /// Returns a greeting string from `puha-lib`.
 pub fn greet() -> &'static str {
     "Hello from puha-lib!"
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Item {
     name: String,
     description: String,
@@ -60,7 +62,7 @@ impl Item {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Space {
     name: String,
     items: Vec<Item>,
@@ -169,6 +171,23 @@ impl Space {
         }
         None
     }
+
+    pub fn save_to_file<P: AsRef<std::path::Path>>(
+        &self,
+        path: P,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let json = serde_json::to_string_pretty(self)?;
+        std::fs::write(path, json)?;
+        Ok(())
+    }
+
+    pub fn from_file<P: AsRef<std::path::Path>>(
+        path: P,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        let data = std::fs::read_to_string(path)?;
+        let space = serde_json::from_str(&data)?;
+        Ok(space)
+    }
 }
 
 #[cfg(test)]
@@ -202,5 +221,30 @@ mod tests {
         assert_eq!(found.name(), "child");
         assert_eq!(found.items().len(), 1);
         assert_eq!(found.items()[0], item);
+    }
+
+    #[test]
+    fn save_and_load_space() {
+        let item = Item::builder()
+            .name("item1")
+            .description("desc")
+            .build();
+
+        let child = Space::builder()
+            .name("child")
+            .push_item(item.clone())
+            .build();
+
+        let root = Space::builder()
+            .name("root")
+            .root(true)
+            .push_space(child)
+            .build();
+
+        let file = tempfile::NamedTempFile::new().unwrap();
+        root.save_to_file(file.path()).unwrap();
+
+        let loaded = Space::from_file(file.path()).unwrap();
+        assert_eq!(loaded, root);
     }
 }


### PR DESCRIPTION
## Summary
- serialize Item and Space structs using serde
- allow saving and loading `Space` to/from JSON files
- test serialization round trip
- add serde/serde_json and tempfile dependencies

## Testing
- `cargo fmt --all` *(fails: rustfmt component not installed)*
- `cargo test` *(fails: could not download serde crate due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68463b8075108331bf2e74135a401fc0